### PR TITLE
Document GitHub Enterprise Server upgrade commands

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -994,7 +994,7 @@ Check if esstential ports are reachable on the cluster nodes.
 gh es upgrade
 ```
 
-Manage upgrades on GitHub Enterprise Server instances. Upgrades proceed through two phases: the pre-upgrade phase validates and prepares the environment, while the upgrade phase applies the new version. Both phases can be run independently or together as a full upgrade.
+Manage upgrades on GitHub Enterprise Server instances version 3.22.0 and later. Upgrades proceed through two phases: the pre-upgrade phase validates and prepares the environment, while the upgrade phase applies the new version. Both phases can be run independently or together as a full upgrade.
 
 > [!IMPORTANT]
 > Before beginning an upgrade, back up your data with [GitHub Enterprise Server Backup Utilities](https://github.com/github/backup-utils#readme) and schedule a maintenance window.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1123,19 +1123,18 @@ Download an upgrade package to all configured nodes of a GitHub Enterprise Serve
 
 <dl class="flags">
 <dt><code>--version &lt;string&gt;</code></dt>
-<dd>Version of the upgrade package to download</dd>
-
+<dd>Version of the upgrade package to download (omit to download the latest available version)</dd>
 <dt><code>--force</code></dt>
 <dd>Force re-download even if the package already exists</dd>
 
 <dt><code>--batch-size &lt;int&gt;</code></dt>
-<dd>Maximum number of nodes to download to concurrently. Defaults to 0 (all nodes)</dd>
+<dd>Maximum number of nodes to download to concurrently. Defaults to 0 (no limit; download to all nodes concurrently)</dd>
 
 <dt><code>--poll-interval &lt;duration&gt;</code></dt>
 <dd>Polling interval for batched downloads (default: 30s)</dd>
 
 <dt><code>--batch-timeout &lt;duration&gt;</code></dt>
-<dd>Maximum time to wait for one node download before marking it stuck (default: 1h)</dd>
+<dd>Maximum time to wait for one node download before marking it as stuck (default: 1h)</dd>
 
 <dt><code>--max-attempts &lt;int&gt;</code></dt>
 <dd>Maximum number of download attempts per node for batched downloads (default: 1)</dd>

--- a/USAGE.md
+++ b/USAGE.md
@@ -988,4 +988,232 @@ Check if esstential ports are reachable on the cluster nodes.
 <dd>Format results as JSON</dd>
 </dl>
 
+## gh es upgrade
 
+```
+gh es upgrade
+```
+
+Manage upgrades on GitHub Enterprise Server instances. Upgrades proceed through two phases: the pre-upgrade phase validates and prepares the environment, while the upgrade phase applies the new version. Both phases can be run independently or together as a full upgrade.
+
+> [!IMPORTANT]
+> Before beginning an upgrade, back up your data with [GitHub Enterprise Server Backup Utilities](https://github.com/github/backup-utils#readme) and schedule a maintenance window.
+
+## gh es upgrade apply
+
+```
+gh es upgrade apply [flags]
+```
+
+Apply an upgrade package on a GitHub Enterprise Server (GHES) node. Run the full upgrade (pre-upgrade + upgrade), or a specific phase.
+
+### Options
+
+
+<dl class="flags">
+<dt><code>-p</code>, <code>--upgrade-package-file &lt;string&gt;</code></dt>
+<dd>Path to the upgrade package file (must be under /var/lib/ghe-updates/)</dd>
+
+<dt><code>--version &lt;string&gt;</code></dt>
+<dd>Target upgrade version in major.minor.patch format (e.g. 3.19.3)</dd>
+
+<dt><code>-u</code>, <code>--uuid &lt;string&gt;</code></dt>
+<dd>UUID of the node to run upgrade on</dd>
+
+<dt><code>-t</code>, <code>--target-partition &lt;string&gt;</code></dt>
+<dd>Target partition for the upgrade (optional)</dd>
+
+<dt><code>--phase &lt;string&gt;</code></dt>
+<dd>Upgrade phase to run: 'pre-upgrade' or 'upgrade' (omit for full upgrade)</dd>
+
+<dt><code>-s</code>, <code>--skip-reboot</code></dt>
+<dd>Skip reboot after upgrade</dd>
+</dl>
+
+
+### Options inherited from parent commands
+
+
+<dl class="flags">
+<dt><code>--address &lt;string&gt;</code></dt>
+<dd>The address of the GHES server</dd>
+
+<dt><code>--json</code></dt>
+<dd>Format results as JSON</dd>
+</dl>
+
+
+### Examples
+
+```bash
+# Run a full upgrade (pre-upgrade + upgrade phases)
+$ gh es upgrade apply --upgrade-package-file /var/lib/ghe-updates/github-enterprise-3.19.3.pkg
+
+# Run only the pre-upgrade phase
+$ gh es upgrade apply --version 3.19.3 --phase pre-upgrade
+
+# Run only the upgrade phase
+$ gh es upgrade apply --upgrade-package-file /var/lib/ghe-updates/github-enterprise-3.19.3.pkg --phase upgrade
+
+# Run a full upgrade, skipping reboot
+$ gh es upgrade apply --version 3.19.3 --skip-reboot
+
+# Run on a specific node by UUID (for HA/cluster environments)
+$ gh es upgrade apply --upgrade-package-file /var/lib/ghe-updates/github-enterprise-3.19.3.pkg --uuid <node-uuid>
+
+# Run with a specific target partition (optional)
+$ gh es upgrade apply --version 3.19.3 --target-partition /dev/sda2
+```
+
+## gh es upgrade status
+
+```
+gh es upgrade status [flags]
+```
+
+Get the upgrade status from all configured nodes of a GitHub Enterprise Server (GHES) instance.
+
+### Options
+
+
+<dl class="flags">
+<dt><code>-u</code>, <code>--uuid &lt;string&gt;</code></dt>
+<dd>UUID of the node to get upgrade status from</dd>
+
+<dt><code>-v</code>, <code>--verbose</code></dt>
+<dd>Show detailed step information</dd>
+</dl>
+
+
+### Options inherited from parent commands
+
+
+<dl class="flags">
+<dt><code>--address &lt;string&gt;</code></dt>
+<dd>The address of the GHES server</dd>
+
+<dt><code>--json</code></dt>
+<dd>Format results as JSON</dd>
+</dl>
+
+
+### Examples
+
+```bash
+# Get upgrade status from all nodes
+$ gh es upgrade status
+
+# Get upgrade status from a specific node by UUID
+$ gh es upgrade status --uuid <node-uuid>
+
+# Get upgrade status with detailed step information
+$ gh es upgrade status --verbose
+```
+
+## gh es upgrade download
+
+```
+gh es upgrade download [flags]
+```
+
+Download an upgrade package to all configured nodes of a GitHub Enterprise Server (GHES) instance.
+
+### Options
+
+
+<dl class="flags">
+<dt><code>--version &lt;string&gt;</code></dt>
+<dd>Version of the upgrade package to download</dd>
+
+<dt><code>--force</code></dt>
+<dd>Force re-download even if the package already exists</dd>
+
+<dt><code>--batch-size &lt;int&gt;</code></dt>
+<dd>Maximum number of nodes to download to concurrently. Defaults to 0 (all nodes)</dd>
+
+<dt><code>--poll-interval &lt;duration&gt;</code></dt>
+<dd>Polling interval for batched downloads (default: 30s)</dd>
+
+<dt><code>--batch-timeout &lt;duration&gt;</code></dt>
+<dd>Maximum time to wait for one node download before marking it stuck (default: 1h)</dd>
+
+<dt><code>--max-attempts &lt;int&gt;</code></dt>
+<dd>Maximum number of download attempts per node for batched downloads (default: 1)</dd>
+</dl>
+
+
+### Options inherited from parent commands
+
+
+<dl class="flags">
+<dt><code>--address &lt;string&gt;</code></dt>
+<dd>The address of the GHES server</dd>
+
+<dt><code>--json</code></dt>
+<dd>Format results as JSON</dd>
+</dl>
+
+
+### Examples
+
+```bash
+# Download the latest upgrade package
+$ gh es upgrade download
+
+# Download a specific version
+$ gh es upgrade download --version 3.19.2
+
+# Force re-download even if package exists
+$ gh es upgrade download --force
+
+# Download to up to two nodes at a time
+$ gh es upgrade download --batch-size 2
+
+# Poll queued downloads every 30 seconds
+$ gh es upgrade download --batch-size 2 --poll-interval 30s
+
+# Mark a node download as stuck if not finished after one hour
+$ gh es upgrade download --batch-size 2 --batch-timeout 1h
+
+# Retry failed node downloads up to three total attempts
+$ gh es upgrade download --batch-size 2 --max-attempts 3
+```
+
+## gh es upgrade download status
+
+```
+gh es upgrade download status [flags]
+```
+
+Get upgrade package download and distribution status from a GitHub Enterprise Server (GHES) instance.
+
+### Options
+
+
+<dl class="flags">
+<dt><code>-u</code>, <code>--uuid &lt;string&gt;</code></dt>
+<dd>UUID of the node to get download status from</dd>
+</dl>
+
+
+### Options inherited from parent commands
+
+
+<dl class="flags">
+<dt><code>--address &lt;string&gt;</code></dt>
+<dd>The address of the GHES server</dd>
+
+<dt><code>--json</code></dt>
+<dd>Format results as JSON</dd>
+</dl>
+
+
+### Examples
+
+```bash
+# Get upgrade package download status from all nodes
+$ gh es upgrade download status
+
+# Get upgrade package download status from a specific node
+$ gh es upgrade download status --uuid <node-uuid>
+```


### PR DESCRIPTION
Added documentation for GitHub Enterprise Server upgrade commands including usage, options, and examples.

This should merge with the 3.22 release